### PR TITLE
feat(member): 회원 토큰 검증 API 변경

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -2,7 +2,7 @@
 :doctype: book
 :source-highlighter: highlightjs
 :toc: left
-:toclevels: 2
+:toclevels: 3
 :sectlinks:
 
 include::member.adoc[]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -1,14 +1,18 @@
 == 회원
 
+=== 회원 정보 조회
+
+operation::member-controller-test/info_member[snippets='http-request,http-response']
+
 === 회원 가입
 
 operation::member-controller-test/register_member[snippets='http-request,http-response']
 
-=== [ERROR] 회원 가입 시 이메일 중복
+==== [ERROR] 회원 가입 시 이메일 중복
 
 operation::member-controller-test/duplicate_register_member[snippets='http-request,http-response']
 
-=== [ERROR] 이미 로그인에 성공한 사용자가 회원가입 시도
+==== [ERROR] 이미 로그인에 성공한 사용자가 회원가입 시도
 
 operation::member-controller-test/already_login_member_register[snippets='http-request,http-response']
 
@@ -16,7 +20,7 @@ operation::member-controller-test/already_login_member_register[snippets='http-r
 
 operation::member-controller-test/verify_member_token[snippets='http-request,http-response']
 
-=== [ERROR] 유효하지 않은 회원 토큰으로 검증 시도
+==== [ERROR] 유효하지 않은 회원 토큰으로 검증 시도
 
 operation::member-controller-test/verify_member_invalid_token[snippets='http-request,http-response']
 
@@ -24,22 +28,22 @@ operation::member-controller-test/verify_member_invalid_token[snippets='http-req
 
 operation::member-controller-test/login[snippets='http-request,http-response']
 
-=== [ERROR] 존재하지 않는 이메일로 로그인 시도
+==== [ERROR] 존재하지 않는 이메일로 로그인 시도
 
 operation::member-controller-test/login_notfound_member[snippets='http-request,http-response']
 
-=== [ERROR] 이미 로그인에 성공한 사용자가 로그인 시도
+==== [ERROR] 이미 로그인에 성공한 사용자가 로그인 시도
 
 operation::member-controller-test/already_login_member_login[snippets='http-request,http-response']
 
 === 구글 로그인
 
-==== request
+==== HTTP request
 
 해당 URL로 접속하여 로그인 합니다. +
 http://localhost:8081/api/oauth2/authorization/google
 
-==== response
+==== HTTP response
 
 로그인에 성공하면 해당 URL로 리다이렉트 됩니다. +
 http://localhost:3000/oauth/success?token=ACCESS_TOKEN
@@ -48,22 +52,30 @@ http://localhost:3000/oauth/success?token=ACCESS_TOKEN
 
 operation::member-controller-test/send_change_password_email[snippets='http-request,http-response']
 
-=== Case 로그인 회원 비밀번호 변경
+==== REDIRECT
+
+사용자는 비밀번호 찾기 이메일을 수신합니다. +
+수신한 이메일을 통해 접속하는 페이지 URL 입니다. +
+http://localhost:3000/members/password/reset?token=ACCESS_TOKEN
+
+=== 비밀번호 변경
+
+==== Case 비밀번호 찾기 비밀번호 변경
+
+operation::member-controller-test/reset_password[snippets='http-request,http-response']
+
+==== Case 로그인 회원 비밀번호 변경
 
 operation::member-controller-test/change_member_password[snippets='http-request,http-response']
 
-=== [ERROR] 비밀번호 변경 시 기존 비밀번호가 일치하지 않음
+==== [ERROR] 비밀번호 변경 시 기존 비밀번호가 일치하지 않음
 
 operation::member-controller-test/invalid_change_password[snippets='http-request,http-response']
-
-=== Case 비밀번호 찾기 비밀번호 변경
-
-operation::member-controller-test/reset_password[snippets='http-request,http-response']
 
 === 휴대폰 번호 변경
 
 operation::member-controller-test/change_phone_number[snippets='http-request,http-response']
 
-=== [ERROR] 유효하지 않은 휴대폰 번호 형식
+==== [ERROR] 유효하지 않은 휴대폰 번호 형식
 
 operation::member-controller-test/invalid_phone_number[snippets='http-request,http-response']

--- a/src/main/java/com/handwoong/rainbowletter/config/security/AccessAllowUri.java
+++ b/src/main/java/com/handwoong/rainbowletter/config/security/AccessAllowUri.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum AccessAllowUri implements AllowUri {
     ROOT("/"),
     INDEX("/index.html"),
-    EMAIL_VERIFY("/api/members/verify/**"),
-    REPLY_LETTER("/api/letters");
+    REPLY_LETTER("/api/letters"),
+    ;
 
     private final String uri;
 }

--- a/src/main/java/com/handwoong/rainbowletter/controller/member/MemberController.java
+++ b/src/main/java/com/handwoong/rainbowletter/controller/member/MemberController.java
@@ -7,13 +7,14 @@ import com.handwoong.rainbowletter.dto.member.FindPasswordDto;
 import com.handwoong.rainbowletter.dto.member.MemberLoginRequest;
 import com.handwoong.rainbowletter.dto.member.MemberRegisterRequest;
 import com.handwoong.rainbowletter.dto.member.MemberRegisterResponse;
+import com.handwoong.rainbowletter.dto.member.MemberResponse;
 import com.handwoong.rainbowletter.service.member.MemberService;
 import com.handwoong.rainbowletter.util.SecurityUtils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,15 +27,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
     private final MemberService memberService;
 
+    @GetMapping("/info")
+    public ResponseEntity<MemberResponse> info() {
+        final String email = SecurityUtils.getAuthenticationUsername();
+        final MemberResponse response = memberService.info(email);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
     @PostMapping
     public ResponseEntity<MemberRegisterResponse> register(@RequestBody @Valid final MemberRegisterRequest request) {
         final MemberRegisterResponse response = memberService.register(request);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
-    @PostMapping("/verify/{token}")
-    public ResponseEntity<Void> verify(@PathVariable final String token) {
-        memberService.verify(token);
+    @PostMapping("/verify")
+    public ResponseEntity<Void> verify() {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/src/main/java/com/handwoong/rainbowletter/dto/member/MemberResponse.java
+++ b/src/main/java/com/handwoong/rainbowletter/dto/member/MemberResponse.java
@@ -1,0 +1,11 @@
+package com.handwoong.rainbowletter.dto.member;
+
+import com.handwoong.rainbowletter.domain.member.MemberRole;
+
+public record MemberResponse(
+        Long id,
+        String email,
+        String phoneNumber,
+        MemberRole role
+) {
+}

--- a/src/main/java/com/handwoong/rainbowletter/repository/member/MemberRepository.java
+++ b/src/main/java/com/handwoong/rainbowletter/repository/member/MemberRepository.java
@@ -1,5 +1,6 @@
 package com.handwoong.rainbowletter.repository.member;
 
+import com.handwoong.rainbowletter.dto.member.MemberResponse;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,6 +9,8 @@ import com.handwoong.rainbowletter.domain.member.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(final String email);
+
+    MemberResponse findInfoByEmail(final String email);
 
     boolean existsByEmail(final String email);
 }

--- a/src/main/java/com/handwoong/rainbowletter/service/mail/template/EmailVerifyTemplate.java
+++ b/src/main/java/com/handwoong/rainbowletter/service/mail/template/EmailVerifyTemplate.java
@@ -33,7 +33,7 @@ public class EmailVerifyTemplate implements EmailTemplate {
     private String createBody(final String email) {
         final TokenResponse tokenResponse =
                 tokenProvider.generateToken(GrantType.PATH_VARIABLE, email, EmailTemplateType.VERIFY.name());
-        final String verifyUrl = propertiesConfig.getClientUrls().get(0) + "/members/verify/" + tokenResponse.token();
+        final String verifyUrl = propertiesConfig.getClientUrls().get(0) + "/members/verify?token=" + tokenResponse.token();
         final Context context = new Context();
         context.setVariable("verifyUrl", verifyUrl);
         return templateEngine.process("verify", context);

--- a/src/main/java/com/handwoong/rainbowletter/service/mail/template/FindPasswordTemplate.java
+++ b/src/main/java/com/handwoong/rainbowletter/service/mail/template/FindPasswordTemplate.java
@@ -32,7 +32,7 @@ public class FindPasswordTemplate implements EmailTemplate {
         final TokenResponse tokenResponse =
                 tokenProvider.generateToken(GrantType.PATH_VARIABLE, email, EmailTemplateType.VERIFY.name());
         final String resetPasswordUrl =
-                propertiesConfig.getClientUrls().get(0) + "/members/password/reset/" + tokenResponse.token();
+                propertiesConfig.getClientUrls().get(0) + "/members/password/reset?token=" + tokenResponse.token();
         final Context context = new Context();
         context.setVariable("resetPasswordUrl", resetPasswordUrl);
         return templateEngine.process("resetPassword", context);

--- a/src/main/java/com/handwoong/rainbowletter/service/member/MemberService.java
+++ b/src/main/java/com/handwoong/rainbowletter/service/member/MemberService.java
@@ -8,11 +8,12 @@ import com.handwoong.rainbowletter.dto.member.FindPasswordDto;
 import com.handwoong.rainbowletter.dto.member.MemberLoginRequest;
 import com.handwoong.rainbowletter.dto.member.MemberRegisterRequest;
 import com.handwoong.rainbowletter.dto.member.MemberRegisterResponse;
+import com.handwoong.rainbowletter.dto.member.MemberResponse;
 
 public interface MemberService {
-    MemberRegisterResponse register(final MemberRegisterRequest request);
+    MemberResponse info(final String email);
 
-    void verify(final String token);
+    MemberRegisterResponse register(final MemberRegisterRequest request);
 
     TokenResponse login(final MemberLoginRequest request);
 

--- a/src/main/java/com/handwoong/rainbowletter/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/handwoong/rainbowletter/service/member/MemberServiceImpl.java
@@ -12,6 +12,7 @@ import com.handwoong.rainbowletter.dto.member.FindPasswordDto;
 import com.handwoong.rainbowletter.dto.member.MemberLoginRequest;
 import com.handwoong.rainbowletter.dto.member.MemberRegisterRequest;
 import com.handwoong.rainbowletter.dto.member.MemberRegisterResponse;
+import com.handwoong.rainbowletter.dto.member.MemberResponse;
 import com.handwoong.rainbowletter.exception.ErrorCode;
 import com.handwoong.rainbowletter.exception.RainbowLetterException;
 import com.handwoong.rainbowletter.repository.member.MemberRepository;
@@ -35,6 +36,11 @@ public class MemberServiceImpl implements MemberService {
     private final AuthenticationManagerBuilder authenticationBuilder;
 
     @Override
+    public MemberResponse info(final String email) {
+        return memberRepository.findInfoByEmail(email);
+    }
+
+    @Override
     @Transactional
     public MemberRegisterResponse register(final MemberRegisterRequest request) {
         validateDuplicateEmail(request.email());
@@ -44,15 +50,6 @@ public class MemberServiceImpl implements MemberService {
         member.changeStatus(MemberStatus.ACTIVE);
         memberRepository.save(member);
         return MemberRegisterResponse.from(member);
-    }
-
-    @Override
-    public void verify(final String token) {
-        final String email = tokenProvider.parseVerifyToken(token);
-        final boolean isExistsByEmail = memberRepository.existsByEmail(email);
-        if (!isExistsByEmail) {
-            throw new RainbowLetterException(ErrorCode.INVALID_EMAIL, email);
-        }
     }
 
     private void validateDuplicateEmail(final String email) {

--- a/src/test/java/com/handwoong/rainbowletter/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/handwoong/rainbowletter/controller/member/MemberControllerTest.java
@@ -58,6 +58,17 @@ public class MemberControllerTest extends ControllerTestProvider {
     }
 
     @Test
+    @DisplayName("회원 정보를 조회한다.")
+    void info_member() {
+        // given
+        // when
+        final ExtractableResponse<Response> response = info(userAccessToken);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
     @DisplayName("유효한 회원가입 요청이 들어오면 회원가입에 성공한다.")
     void register_member() {
         // given
@@ -115,7 +126,7 @@ public class MemberControllerTest extends ControllerTestProvider {
 
         // then
         assertThat(verifyResponse.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-        assertThat(verifyResponse.body().jsonPath().getString("message")).isEqualTo("유효하지 않은 토큰입니다.");
+        assertThat(verifyResponse.body().jsonPath().getString("message")).isEqualTo("인증에 실패하였습니다.");
     }
 
     @Test
@@ -251,6 +262,15 @@ public class MemberControllerTest extends ControllerTestProvider {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
+    private ExtractableResponse<Response> info(final String token) {
+        return RestAssured
+                .given(getSpecification()).log().all()
+                .header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_TYPE + " " + token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/api/members/info")
+                .then().log().all().extract();
+    }
+
     private ExtractableResponse<Response> register(final MemberRegisterRequest registerRequest, final String token) {
         return RestAssured
                 .given(getSpecification()).log().all()
@@ -264,8 +284,9 @@ public class MemberControllerTest extends ControllerTestProvider {
     private ExtractableResponse<Response> verify(final String token) {
         return RestAssured
                 .given(getSpecification()).log().all()
+                .header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_TYPE + " " + token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/api/members/verify/" + token)
+                .when().post("/api/members/verify")
                 .then().log().all().extract();
     }
 


### PR DESCRIPTION
## 설명

회원 토큰을 Authorization 헤더를 사용하여 검증한다.

## 작업

- [x] 회원 토큰 검증 API 변경
- [x] 이메일 발송 시 사용되는 토큰 쿼리 스트링으로 전달
- [x] API 명세 수정
- [x] 회원 정보 조회 API 구현

Close #58 