### PR TITLE
refactor: 읽기, 쓰기 쿼리 개선

### DIFF
--- a/src/docs/asciidoc/image.adoc
+++ b/src/docs/asciidoc/image.adoc
@@ -8,7 +8,6 @@
 ----
 POST /api/images/upload?type=PET HTTP/1.1
 Authorization: Bearer 토큰
-Content-Type: multipart/form-data
 ----
 
 operation::image-controller-test/이미지_업로드[snippets='query-parameters,request-headers,request-parts,http-response,response-fields']

--- a/src/main/java/com/handwoong/rainbowletter/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/handwoong/rainbowletter/common/exception/DefaultExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.handwoong.rainbowletter.common.exception;
 
+import org.apache.tomcat.util.http.fileupload.FileUploadException;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.http.ResponseEntity;
@@ -8,6 +9,9 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MultipartException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 @RestControllerAdvice
 @Order
@@ -41,9 +45,23 @@ public class DefaultExceptionHandler extends BaseExceptionHandler {
         return createErrorResponse(errorCode);
     }
 
-    @ExceptionHandler({ConversionFailedException.class})
-    public ResponseEntity<ErrorResponse> conversionFailed(final ConversionFailedException exception) {
-        final ErrorCode errorCode = ErrorCode.INVALID_PARAM_VALUE;
+    @ExceptionHandler({MethodArgumentTypeMismatchException.class, ConversionFailedException.class})
+    public ResponseEntity<ErrorResponse> invalidPathValue(final Exception exception) {
+        final ErrorCode errorCode = ErrorCode.INVALID_PATH_VALUE;
+        logWarn(errorCode, exception.getMessage());
+        return createErrorResponse(errorCode);
+    }
+
+    @ExceptionHandler({MissingServletRequestPartException.class})
+    public ResponseEntity<ErrorResponse> missingServletRequestPart(final MissingServletRequestPartException exception) {
+        final ErrorCode errorCode = ErrorCode.REQUIRED_FILE;
+        logWarn(errorCode, exception.getMessage());
+        return createErrorResponse(errorCode);
+    }
+
+    @ExceptionHandler({MultipartException.class, FileUploadException.class})
+    public ResponseEntity<ErrorResponse> multipart(final Exception exception) {
+        final ErrorCode errorCode = ErrorCode.INVALID_FILE_CONTENT_TYPE;
         logWarn(errorCode, exception.getMessage());
         return createErrorResponse(errorCode);
     }

--- a/src/main/java/com/handwoong/rainbowletter/common/exception/ErrorCode.java
+++ b/src/main/java/com/handwoong/rainbowletter/common/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     MAIL_TEMPLATE_NOT_FOUND(BAD_REQUEST, "이메일 템플릿을 찾을 수 없습니다."),
     FAIL_UPLOAD_IMAGE(BAD_REQUEST, "이미지 업로드에 실패했습니다. 잠시 후 다시 시도해 주세요."),
 
+    INVALID_PERSONALITY_FORMAT(BAD_REQUEST, "유효하지 않은 반려동물 성격 형식입니다."),
     INVALID_FAVORITE_INCREASE(BAD_REQUEST, "하루 최대 좋아요 수를 달성하였습니다."),
 
     INVALID_SUMMARY_FORMAT(BAD_REQUEST, "제목의 길이는 20자 이하로 입력해주세요."),

--- a/src/main/java/com/handwoong/rainbowletter/common/exception/ErrorCode.java
+++ b/src/main/java/com/handwoong/rainbowletter/common/exception/ErrorCode.java
@@ -17,8 +17,10 @@ public enum ErrorCode {
     /**
      * 400 BAD REQUEST
      */
-    INVALID_PARAM_VALUE(BAD_REQUEST, "유효하지 않은 쿼리 파라미터 값입니다."),
+    INVALID_PATH_VALUE(BAD_REQUEST, "요청 주소에 유효하지 않은 값이 있습니다."),
     METHOD_ARGUMENT_NOT_VALID(BAD_REQUEST, "요청 인자가 잘못되었습니다."),
+    REQUIRED_FILE(BAD_REQUEST, "파일을 첨부해주세요."),
+    INVALID_FILE_CONTENT_TYPE(BAD_REQUEST, "Content-Type을 명시하였거나, 폼 데이터에 파일이 없습니다."),
 
     INVALID_EMAIL_FORMAT(BAD_REQUEST, "유효하지 않은 이메일 형식입니다."),
     INVALID_EMAIL(BAD_REQUEST, "존재하지 않는 이메일입니다."),

--- a/src/main/java/com/handwoong/rainbowletter/pet/controller/PetController.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/controller/PetController.java
@@ -31,8 +31,8 @@ public class PetController {
     @GetMapping
     public ResponseEntity<PetResponses> findAll() {
         final Email email = SecurityUtils.getAuthenticationUsername();
-        final List<Pet> pets = petService.findAllByEmail(email);
-        final PetResponses response = PetResponses.from(pets);
+        final List<PetResponse> petResponses = petService.findAllByEmail(email);
+        final PetResponses response = PetResponses.from(petResponses);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/handwoong/rainbowletter/pet/controller/port/PetService.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/controller/port/PetService.java
@@ -1,6 +1,7 @@
 package com.handwoong.rainbowletter.pet.controller.port;
 
 import com.handwoong.rainbowletter.member.domain.Email;
+import com.handwoong.rainbowletter.pet.controller.response.PetResponse;
 import com.handwoong.rainbowletter.pet.domain.Pet;
 import com.handwoong.rainbowletter.pet.domain.dto.PetCreate;
 import com.handwoong.rainbowletter.pet.domain.dto.PetUpdate;
@@ -9,7 +10,7 @@ import java.util.List;
 public interface PetService {
     Pet findByEmailAndIdOrElseThrow(Email email, Long id);
 
-    List<Pet> findAllByEmail(Email email);
+    List<PetResponse> findAllByEmail(Email email);
 
     Pet create(Email email, PetCreate request);
 

--- a/src/main/java/com/handwoong/rainbowletter/pet/controller/request/PetCreateRequest.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/controller/request/PetCreateRequest.java
@@ -7,7 +7,10 @@ import static com.handwoong.rainbowletter.common.util.validation.ValidateMessage
 import static com.handwoong.rainbowletter.common.util.validation.ValidateMessage.PET_PERSONALITY;
 import static com.handwoong.rainbowletter.common.util.validation.ValidateMessage.PET_PERSONALITY_SIZE;
 import static com.handwoong.rainbowletter.common.util.validation.ValidateMessage.PET_SPECIES;
+import static com.handwoong.rainbowletter.pet.domain.Personalities.MAX_PERSONALITY_LENGTH;
+import static com.handwoong.rainbowletter.pet.domain.Personalities.MAX_PERSONALITY_SIZE;
 
+import com.handwoong.rainbowletter.pet.domain.Personalities;
 import com.handwoong.rainbowletter.pet.domain.dto.PetCreate;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
@@ -29,8 +32,8 @@ public record PetCreateRequest(
         @Size(max = 10, message = PET_OWNER)
         String owner,
 
-        @Size(max = 3, message = PET_PERSONALITY_SIZE)
-        Set<@NotBlank(message = EMPTY_MESSAGE) @Size(max = 10, message = PET_PERSONALITY) String> personalities,
+        @Size(max = MAX_PERSONALITY_SIZE, message = PET_PERSONALITY_SIZE)
+        Set<@NotBlank(message = EMPTY_MESSAGE) @Size(max = MAX_PERSONALITY_LENGTH, message = PET_PERSONALITY) String> personalities,
 
         @Nullable
         @Past(message = PET_DEATH_ANNIVERSARY)
@@ -44,7 +47,7 @@ public record PetCreateRequest(
                 .name(name)
                 .species(species)
                 .owner(owner)
-                .personalities(personalities)
+                .personalities(Personalities.from(personalities))
                 .deathAnniversary(deathAnniversary)
                 .image(image)
                 .build();

--- a/src/main/java/com/handwoong/rainbowletter/pet/controller/request/PetUpdateRequest.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/controller/request/PetUpdateRequest.java
@@ -6,7 +6,10 @@ import static com.handwoong.rainbowletter.common.util.validation.ValidateMessage
 import static com.handwoong.rainbowletter.common.util.validation.ValidateMessage.PET_PERSONALITY;
 import static com.handwoong.rainbowletter.common.util.validation.ValidateMessage.PET_PERSONALITY_SIZE;
 import static com.handwoong.rainbowletter.common.util.validation.ValidateMessage.PET_SPECIES;
+import static com.handwoong.rainbowletter.pet.domain.Personalities.MAX_PERSONALITY_LENGTH;
+import static com.handwoong.rainbowletter.pet.domain.Personalities.MAX_PERSONALITY_SIZE;
 
+import com.handwoong.rainbowletter.pet.domain.Personalities;
 import com.handwoong.rainbowletter.pet.domain.dto.PetUpdate;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
@@ -24,8 +27,8 @@ public record PetUpdateRequest(
         @Size(max = 10, message = PET_OWNER)
         String owner,
 
-        @Size(max = 3, message = PET_PERSONALITY_SIZE)
-        Set<@NotBlank(message = EMPTY_MESSAGE) @Size(max = 10, message = PET_PERSONALITY) String> personalities,
+        @Size(max = MAX_PERSONALITY_SIZE, message = PET_PERSONALITY_SIZE)
+        Set<@NotBlank(message = EMPTY_MESSAGE) @Size(max = MAX_PERSONALITY_LENGTH, message = PET_PERSONALITY) String> personalities,
 
         @Nullable
         @Past(message = PET_DEATH_ANNIVERSARY)
@@ -38,7 +41,7 @@ public record PetUpdateRequest(
         return PetUpdate.builder()
                 .species(species)
                 .owner(owner)
-                .personalities(personalities)
+                .personalities(Personalities.from(personalities))
                 .deathAnniversary(deathAnniversary)
                 .image(image)
                 .build();

--- a/src/main/java/com/handwoong/rainbowletter/pet/controller/response/PetResponse.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/controller/response/PetResponse.java
@@ -2,6 +2,7 @@ package com.handwoong.rainbowletter.pet.controller.response;
 
 import com.handwoong.rainbowletter.favorite.controller.response.FavoriteResponse;
 import com.handwoong.rainbowletter.image.controller.response.ImageResponse;
+import com.handwoong.rainbowletter.pet.domain.Personalities;
 import com.handwoong.rainbowletter.pet.domain.Pet;
 import java.time.LocalDate;
 import java.util.Set;
@@ -24,7 +25,7 @@ public record PetResponse(
                 .name(pet.name())
                 .species(pet.species())
                 .owner(pet.owner())
-                .personalities(pet.personalities())
+                .personalities(Personalities.from(pet.personalities()).personalities())
                 .deathAnniversary(pet.deathAnniversary())
                 .image(ImageResponse.from(pet.image()))
                 .favorite(FavoriteResponse.from(pet.favorite()))

--- a/src/main/java/com/handwoong/rainbowletter/pet/controller/response/PetResponse.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/controller/response/PetResponse.java
@@ -31,4 +31,17 @@ public record PetResponse(
                 .favorite(FavoriteResponse.from(pet.favorite()))
                 .build();
     }
+
+    public static PetResponse from(final PetResponseDto petResponseDto) {
+        return PetResponse.builder()
+                .id(petResponseDto.id())
+                .name(petResponseDto.name())
+                .species(petResponseDto.species())
+                .owner(petResponseDto.owner())
+                .personalities(Personalities.from(petResponseDto.personalities()).personalities())
+                .deathAnniversary(petResponseDto.deathAnniversary())
+                .image(petResponseDto.image())
+                .favorite(petResponseDto.favorite())
+                .build();
+    }
 }

--- a/src/main/java/com/handwoong/rainbowletter/pet/controller/response/PetResponseDto.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/controller/response/PetResponseDto.java
@@ -1,0 +1,32 @@
+package com.handwoong.rainbowletter.pet.controller.response;
+
+import com.handwoong.rainbowletter.favorite.controller.response.FavoriteResponse;
+import com.handwoong.rainbowletter.image.controller.response.ImageResponse;
+import com.handwoong.rainbowletter.pet.domain.Pet;
+import java.time.LocalDate;
+import lombok.Builder;
+
+@Builder
+public record PetResponseDto(
+        Long id,
+        String name,
+        String species,
+        String owner,
+        String personalities,
+        LocalDate deathAnniversary,
+        ImageResponse image,
+        FavoriteResponse favorite
+) {
+    public static PetResponseDto from(final Pet pet) {
+        return PetResponseDto.builder()
+                .id(pet.id())
+                .name(pet.name())
+                .species(pet.species())
+                .owner(pet.owner())
+                .personalities(pet.personalities())
+                .deathAnniversary(pet.deathAnniversary())
+                .image(ImageResponse.from(pet.image()))
+                .favorite(FavoriteResponse.from(pet.favorite()))
+                .build();
+    }
+}

--- a/src/main/java/com/handwoong/rainbowletter/pet/controller/response/PetResponses.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/controller/response/PetResponses.java
@@ -1,15 +1,11 @@
 package com.handwoong.rainbowletter.pet.controller.response;
 
-import com.handwoong.rainbowletter.pet.domain.Pet;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record PetResponses(List<PetResponse> pets) {
-    public static PetResponses from(final List<Pet> pets) {
-        final List<PetResponse> petResponses = pets.stream()
-                .map(PetResponse::from)
-                .toList();
+    public static PetResponses from(final List<PetResponse> petResponses) {
         return PetResponses.builder()
                 .pets(petResponses)
                 .build();

--- a/src/main/java/com/handwoong/rainbowletter/pet/domain/Personalities.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/domain/Personalities.java
@@ -1,0 +1,62 @@
+package com.handwoong.rainbowletter.pet.domain;
+
+import com.handwoong.rainbowletter.pet.exception.PersonalityFormatNotValidException;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import org.springframework.util.StringUtils;
+
+@Builder
+public record Personalities(Set<String> personalities) {
+    public static final int MAX_PERSONALITY_SIZE = 3;
+    public static final int MAX_PERSONALITY_LENGTH = 10;
+
+    private static final String DELIMITER = ",";
+
+    public Personalities {
+        validateNull(personalities);
+        validateSize(personalities);
+        validateLength(personalities);
+    }
+
+    private void validateNull(final Set<String> personalities) {
+        for (String personality : personalities) {
+            if (!StringUtils.hasText(personality)) {
+                throw new PersonalityFormatNotValidException(personality);
+            }
+        }
+    }
+
+    private void validateSize(final Set<String> personalities) {
+        if (personalities.size() > MAX_PERSONALITY_SIZE) {
+            throw new PersonalityFormatNotValidException(personalities.toString());
+        }
+    }
+
+    private void validateLength(final Set<String> personalities) {
+        for (String personality : personalities) {
+            if (personality.length() > MAX_PERSONALITY_LENGTH) {
+                throw new PersonalityFormatNotValidException(personality);
+            }
+        }
+    }
+
+    public static Personalities from(final String personalities) {
+        final Set<String> target = Arrays.stream(personalities.split(DELIMITER))
+                .filter(StringUtils::hasText)
+                .collect(Collectors.toSet());
+        return from(target);
+    }
+
+    public static Personalities from(final Set<String> personalities) {
+        return Personalities.builder()
+                .personalities(personalities)
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return String.join(DELIMITER, personalities);
+    }
+}

--- a/src/main/java/com/handwoong/rainbowletter/pet/domain/Pet.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/domain/Pet.java
@@ -7,7 +7,6 @@ import com.handwoong.rainbowletter.pet.domain.dto.PetCreate;
 import com.handwoong.rainbowletter.pet.domain.dto.PetUpdate;
 import jakarta.annotation.Nullable;
 import java.time.LocalDate;
-import java.util.Set;
 import lombok.Builder;
 
 @Builder
@@ -16,7 +15,7 @@ public record Pet(
         String name,
         String species,
         String owner,
-        Set<String> personalities,
+        String personalities,
         @Nullable LocalDate deathAnniversary,
         @Nullable Image image,
         Member member,
@@ -27,7 +26,7 @@ public record Pet(
                 .name(request.name())
                 .species(request.species())
                 .owner(request.owner())
-                .personalities(request.personalities())
+                .personalities(request.personalities().toString())
                 .deathAnniversary(request.deathAnniversary())
                 .image(image)
                 .member(member)
@@ -41,7 +40,7 @@ public record Pet(
                 .name(name)
                 .species(request.species())
                 .owner(request.owner())
-                .personalities(request.personalities())
+                .personalities(request.personalities().toString())
                 .deathAnniversary(request.deathAnniversary())
                 .image(image)
                 .member(member)

--- a/src/main/java/com/handwoong/rainbowletter/pet/domain/dto/PetCreate.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/domain/dto/PetCreate.java
@@ -1,8 +1,8 @@
 package com.handwoong.rainbowletter.pet.domain.dto;
 
+import com.handwoong.rainbowletter.pet.domain.Personalities;
 import jakarta.annotation.Nullable;
 import java.time.LocalDate;
-import java.util.Set;
 import lombok.Builder;
 
 @Builder
@@ -10,7 +10,7 @@ public record PetCreate(
         String name,
         String species,
         String owner,
-        Set<String> personalities,
+        Personalities personalities,
         @Nullable LocalDate deathAnniversary,
         @Nullable Long image
 ) {

--- a/src/main/java/com/handwoong/rainbowletter/pet/domain/dto/PetUpdate.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/domain/dto/PetUpdate.java
@@ -1,15 +1,15 @@
 package com.handwoong.rainbowletter.pet.domain.dto;
 
+import com.handwoong.rainbowletter.pet.domain.Personalities;
 import jakarta.annotation.Nullable;
 import java.time.LocalDate;
-import java.util.Set;
 import lombok.Builder;
 
 @Builder
 public record PetUpdate(
         String species,
         String owner,
-        Set<String> personalities,
+        Personalities personalities,
         @Nullable LocalDate deathAnniversary,
         @Nullable Long image
 ) {

--- a/src/main/java/com/handwoong/rainbowletter/pet/exception/PersonalityFormatNotValidException.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/exception/PersonalityFormatNotValidException.java
@@ -1,0 +1,15 @@
+package com.handwoong.rainbowletter.pet.exception;
+
+import com.handwoong.rainbowletter.common.exception.BaseException;
+import com.handwoong.rainbowletter.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class PersonalityFormatNotValidException extends BaseException {
+    private final String personality;
+
+    public PersonalityFormatNotValidException(final String personality) {
+        super(ErrorCode.INVALID_PERSONALITY_FORMAT);
+        this.personality = personality;
+    }
+}

--- a/src/main/java/com/handwoong/rainbowletter/pet/exception/PetExceptionHandler.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/exception/PetExceptionHandler.java
@@ -18,4 +18,11 @@ public class PetExceptionHandler extends BaseExceptionHandler {
         logWarn(errorCode, exception.getId().toString());
         return createErrorResponse(errorCode);
     }
+
+    @ExceptionHandler({PersonalityFormatNotValidException.class})
+    public ResponseEntity<ErrorResponse> personalityFormatNotValid(final PersonalityFormatNotValidException exception) {
+        final ErrorCode errorCode = exception.getErrorCode();
+        logWarn(errorCode, exception.getPersonality());
+        return createErrorResponse(errorCode);
+    }
 }

--- a/src/main/java/com/handwoong/rainbowletter/pet/infrastructure/PetEntity.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/infrastructure/PetEntity.java
@@ -6,23 +6,18 @@ import com.handwoong.rainbowletter.image.infrastructure.ImageEntity;
 import com.handwoong.rainbowletter.member.infrastructure.MemberEntity;
 import com.handwoong.rainbowletter.pet.domain.Pet;
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
-import java.util.HashSet;
 import java.util.Objects;
-import java.util.Set;
 import lombok.Getter;
 import org.hibernate.Hibernate;
 
@@ -45,10 +40,8 @@ public class PetEntity extends BaseEntity {
 
     private LocalDate deathAnniversary;
 
-    @ElementCollection
-    @JoinTable(name = "pet_personality", joinColumns = {@JoinColumn(name = "pet_id", referencedColumnName = "id")})
-    @Column(name = "personality")
-    private Set<String> personalities = new HashSet<>();
+    @NotNull
+    private String personalities;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", referencedColumnName = "id")

--- a/src/main/java/com/handwoong/rainbowletter/pet/infrastructure/PetJpaRepository.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/infrastructure/PetJpaRepository.java
@@ -1,15 +1,6 @@
 package com.handwoong.rainbowletter.pet.infrastructure;
 
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface PetJpaRepository extends JpaRepository<PetEntity, Long> {
-    @Query("SELECT p FROM PetEntity p JOIN FETCH p.favoriteEntity WHERE p.memberEntity.email = :email AND p.id = :petId")
-    Optional<PetEntity> findOneById(@Param("email") final String email, @Param("petId") final Long petId);
-
-    @Query("SELECT DISTINCT p FROM PetEntity p JOIN FETCH p.favoriteEntity WHERE p.memberEntity.email = :email")
-    List<PetEntity> findAll(@Param("email") final String email);
 }

--- a/src/main/java/com/handwoong/rainbowletter/pet/infrastructure/PetJpaRepository.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/infrastructure/PetJpaRepository.java
@@ -7,10 +7,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PetJpaRepository extends JpaRepository<PetEntity, Long> {
-    @Query("SELECT p FROM PetEntity p JOIN FETCH p.personalities JOIN FETCH p.favoriteEntity WHERE p.memberEntity.email = :email AND p.id = :petId")
+    @Query("SELECT p FROM PetEntity p JOIN FETCH p.favoriteEntity WHERE p.memberEntity.email = :email AND p.id = :petId")
     Optional<PetEntity> findOneById(@Param("email") final String email, @Param("petId") final Long petId);
 
-    @Query("SELECT DISTINCT p FROM PetEntity p LEFT OUTER JOIN FETCH p.personalities JOIN FETCH p.favoriteEntity WHERE p.memberEntity.email = :email")
+    @Query("SELECT DISTINCT p FROM PetEntity p JOIN FETCH p.favoriteEntity WHERE p.memberEntity.email = :email")
     List<PetEntity> findAll(@Param("email") final String email);
 
     @Query("SELECT p FROM PetEntity p JOIN FETCH p.imageEntity WHERE p.memberEntity.email = :email AND p.id = :petId")

--- a/src/main/java/com/handwoong/rainbowletter/pet/infrastructure/PetJpaRepository.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/infrastructure/PetJpaRepository.java
@@ -12,7 +12,4 @@ public interface PetJpaRepository extends JpaRepository<PetEntity, Long> {
 
     @Query("SELECT DISTINCT p FROM PetEntity p JOIN FETCH p.favoriteEntity WHERE p.memberEntity.email = :email")
     List<PetEntity> findAll(@Param("email") final String email);
-
-    @Query("SELECT p FROM PetEntity p JOIN FETCH p.imageEntity WHERE p.memberEntity.email = :email AND p.id = :petId")
-    Optional<PetEntity> findOneByIdWithImage(@Param("email") final String email, @Param("petId") final Long petId);
 }

--- a/src/main/java/com/handwoong/rainbowletter/pet/infrastructure/PetRepositoryImpl.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/infrastructure/PetRepositoryImpl.java
@@ -5,10 +5,15 @@ import static com.handwoong.rainbowletter.image.infrastructure.QImageEntity.imag
 import static com.handwoong.rainbowletter.member.infrastructure.QMemberEntity.memberEntity;
 import static com.handwoong.rainbowletter.pet.infrastructure.QPetEntity.petEntity;
 
+import com.handwoong.rainbowletter.favorite.controller.response.FavoriteResponse;
+import com.handwoong.rainbowletter.image.controller.response.ImageResponse;
 import com.handwoong.rainbowletter.member.domain.Email;
+import com.handwoong.rainbowletter.pet.controller.response.PetResponse;
+import com.handwoong.rainbowletter.pet.controller.response.PetResponseDto;
 import com.handwoong.rainbowletter.pet.domain.Pet;
 import com.handwoong.rainbowletter.pet.exception.PetResourceNotFoundException;
 import com.handwoong.rainbowletter.pet.service.port.PetRepository;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
@@ -23,35 +28,79 @@ public class PetRepositoryImpl implements PetRepository {
 
     @Override
     public Pet findByIdOrElseThrow(final Long id) {
-        return petJpaRepository.findById(id)
+        return Optional.ofNullable(
+                        queryFactory.selectFrom(petEntity)
+                                .distinct()
+                                .leftJoin(petEntity.imageEntity)
+                                .fetchJoin()
+                                .innerJoin(petEntity.memberEntity, memberEntity)
+                                .fetchJoin()
+                                .innerJoin(petEntity.favoriteEntity, favoriteEntity)
+                                .fetchJoin()
+                                .where(petEntity.id.eq(id))
+                                .fetchOne()
+                )
                 .orElseThrow(() -> new PetResourceNotFoundException(id))
                 .toModel();
     }
 
     @Override
     public Pet findByEmailAndIdOrElseThrow(final Email email, final Long id) {
-        return findByEmailAndId(email, id)
-                .orElseThrow(() -> new PetResourceNotFoundException(id));
+        return Optional.ofNullable(
+                        queryFactory.selectFrom(petEntity)
+                                .distinct()
+                                .leftJoin(petEntity.imageEntity)
+                                .fetchJoin()
+                                .innerJoin(petEntity.memberEntity, memberEntity)
+                                .fetchJoin()
+                                .innerJoin(petEntity.favoriteEntity, favoriteEntity)
+                                .fetchJoin()
+                                .where(petEntity.id.eq(id).and(petEntity.memberEntity.email.eq(email.toString())))
+                                .fetchOne()
+                )
+                .orElseThrow(() -> new PetResourceNotFoundException(id))
+                .toModel();
     }
 
     @Override
-    public Optional<Pet> findByEmailAndId(final Email email, final Long id) {
-        return petJpaRepository.findOneById(email.toString(), id).map(PetEntity::toModel);
-    }
-
-    @Override
-    public List<Pet> findAllByEmail(final Email email) {
-        return petJpaRepository.findAll(email.toString())
+    public List<PetResponse> findAllByEmail(final Email email) {
+        return queryFactory.select(Projections.constructor(
+                        PetResponseDto.class,
+                        petEntity.id,
+                        petEntity.name,
+                        petEntity.species,
+                        petEntity.owner,
+                        petEntity.personalities,
+                        petEntity.deathAnniversary,
+                        Projections.constructor(
+                                ImageResponse.class,
+                                petEntity.imageEntity.id,
+                                petEntity.imageEntity.objectKey,
+                                petEntity.imageEntity.url
+                        ),
+                        Projections.constructor(
+                                FavoriteResponse.class,
+                                petEntity.favoriteEntity.id,
+                                petEntity.favoriteEntity.total,
+                                petEntity.favoriteEntity.dayIncreaseCount,
+                                petEntity.favoriteEntity.canIncrease
+                        )
+                ))
+                .distinct()
+                .from(petEntity)
+                .innerJoin(petEntity.favoriteEntity, favoriteEntity)
+                .leftJoin(petEntity.imageEntity)
+                .where(petEntity.memberEntity.email.eq(email.toString()))
+                .fetch()
                 .stream()
-                .map(PetEntity::toModel)
+                .map(PetResponse::from)
                 .toList();
     }
 
     @Override
     public Pet findByEmailAndIdWithImageOrElseThrow(final Email email, final Long id) {
         return Optional.ofNullable(
-                        queryFactory.select(petEntity)
-                                .from(petEntity)
+                        queryFactory.selectFrom(petEntity)
                                 .innerJoin(petEntity.imageEntity, imageEntity)
                                 .fetchJoin()
                                 .innerJoin(petEntity.memberEntity, memberEntity)

--- a/src/main/java/com/handwoong/rainbowletter/pet/infrastructure/PetRepositoryImpl.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/infrastructure/PetRepositoryImpl.java
@@ -1,9 +1,15 @@
 package com.handwoong.rainbowletter.pet.infrastructure;
 
+import static com.handwoong.rainbowletter.favorite.infrastructure.QFavoriteEntity.favoriteEntity;
+import static com.handwoong.rainbowletter.image.infrastructure.QImageEntity.imageEntity;
+import static com.handwoong.rainbowletter.member.infrastructure.QMemberEntity.memberEntity;
+import static com.handwoong.rainbowletter.pet.infrastructure.QPetEntity.petEntity;
+
 import com.handwoong.rainbowletter.member.domain.Email;
 import com.handwoong.rainbowletter.pet.domain.Pet;
 import com.handwoong.rainbowletter.pet.exception.PetResourceNotFoundException;
 import com.handwoong.rainbowletter.pet.service.port.PetRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +18,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 @RequiredArgsConstructor
 public class PetRepositoryImpl implements PetRepository {
+    private final JPAQueryFactory queryFactory;
     private final PetJpaRepository petJpaRepository;
 
     @Override
@@ -41,8 +48,21 @@ public class PetRepositoryImpl implements PetRepository {
     }
 
     @Override
-    public Optional<Pet> findByEmailAndIdWithImage(final Email email, final Long id) {
-        return petJpaRepository.findOneByIdWithImage(email.toString(), id).map(PetEntity::toModel);
+    public Pet findByEmailAndIdWithImageOrElseThrow(final Email email, final Long id) {
+        return Optional.ofNullable(
+                        queryFactory.select(petEntity)
+                                .from(petEntity)
+                                .innerJoin(petEntity.imageEntity, imageEntity)
+                                .fetchJoin()
+                                .innerJoin(petEntity.memberEntity, memberEntity)
+                                .fetchJoin()
+                                .innerJoin(petEntity.favoriteEntity, favoriteEntity)
+                                .fetchJoin()
+                                .where(petEntity.id.eq(id).and(petEntity.memberEntity.email.eq(email.toString())))
+                                .fetchOne()
+                )
+                .orElseThrow(() -> new PetResourceNotFoundException(id))
+                .toModel();
     }
 
     @Override

--- a/src/main/java/com/handwoong/rainbowletter/pet/service/PetServiceImpl.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/service/PetServiceImpl.java
@@ -12,7 +12,6 @@ import com.handwoong.rainbowletter.pet.controller.port.PetService;
 import com.handwoong.rainbowletter.pet.domain.Pet;
 import com.handwoong.rainbowletter.pet.domain.dto.PetCreate;
 import com.handwoong.rainbowletter.pet.domain.dto.PetUpdate;
-import com.handwoong.rainbowletter.pet.exception.PetResourceNotFoundException;
 import com.handwoong.rainbowletter.pet.service.port.PetRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -62,8 +61,7 @@ public class PetServiceImpl implements PetService {
     @Override
     @Transactional
     public Pet deleteImage(final Email email, final Long id) {
-        final Pet pet = petRepository.findByEmailAndIdWithImage(email, id)
-                .orElseThrow(() -> new PetResourceNotFoundException(id));
+        final Pet pet = petRepository.findByEmailAndIdWithImageOrElseThrow(email, id);
         assert pet.image() != null;
         amazonS3Service.remove(pet.image().bucket(), pet.image().objectKey());
         final Pet updatePet = pet.removeImage();

--- a/src/main/java/com/handwoong/rainbowletter/pet/service/PetServiceImpl.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/service/PetServiceImpl.java
@@ -9,6 +9,7 @@ import com.handwoong.rainbowletter.member.domain.Email;
 import com.handwoong.rainbowletter.member.domain.Member;
 import com.handwoong.rainbowletter.member.service.port.MemberRepository;
 import com.handwoong.rainbowletter.pet.controller.port.PetService;
+import com.handwoong.rainbowletter.pet.controller.response.PetResponse;
 import com.handwoong.rainbowletter.pet.domain.Pet;
 import com.handwoong.rainbowletter.pet.domain.dto.PetCreate;
 import com.handwoong.rainbowletter.pet.domain.dto.PetUpdate;
@@ -34,7 +35,7 @@ public class PetServiceImpl implements PetService {
     }
 
     @Override
-    public List<Pet> findAllByEmail(final Email email) {
+    public List<PetResponse> findAllByEmail(final Email email) {
         return petRepository.findAllByEmail(email);
     }
 

--- a/src/main/java/com/handwoong/rainbowletter/pet/service/port/PetRepository.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/service/port/PetRepository.java
@@ -1,18 +1,16 @@
 package com.handwoong.rainbowletter.pet.service.port;
 
 import com.handwoong.rainbowletter.member.domain.Email;
+import com.handwoong.rainbowletter.pet.controller.response.PetResponse;
 import com.handwoong.rainbowletter.pet.domain.Pet;
 import java.util.List;
-import java.util.Optional;
 
 public interface PetRepository {
     Pet findByIdOrElseThrow(Long id);
 
     Pet findByEmailAndIdOrElseThrow(Email email, Long id);
 
-    Optional<Pet> findByEmailAndId(Email email, Long id);
-
-    List<Pet> findAllByEmail(Email email);
+    List<PetResponse> findAllByEmail(Email email);
 
     Pet findByEmailAndIdWithImageOrElseThrow(Email email, Long id);
 

--- a/src/main/java/com/handwoong/rainbowletter/pet/service/port/PetRepository.java
+++ b/src/main/java/com/handwoong/rainbowletter/pet/service/port/PetRepository.java
@@ -14,7 +14,7 @@ public interface PetRepository {
 
     List<Pet> findAllByEmail(Email email);
 
-    Optional<Pet> findByEmailAndIdWithImage(Email email, Long id);
+    Pet findByEmailAndIdWithImageOrElseThrow(Email email, Long id);
 
     Pet save(Pet pet);
 

--- a/src/test/java/com/handwoong/rainbowletter/image/controller/snippet/ImageRequestSnippet.java
+++ b/src/test/java/com/handwoong/rainbowletter/image/controller/snippet/ImageRequestSnippet.java
@@ -13,7 +13,7 @@ import org.springframework.restdocs.snippet.Snippet;
 public class ImageRequestSnippet {
     public static final Snippet IMAGE_HEADER = requestHeaders(
             headerWithName("Authorization").description("액세스 토큰"),
-            headerWithName("Content-Type").description("폼 데이터")
+            headerWithName("Content-Type").description("명시하면 안됨")
     );
     public static final Snippet IMAGE_TYPE = queryParameters(
             parameterWithName("type").description("이미지 타입").attributes(constraints("PET || LETTER 대문자"))

--- a/src/test/java/com/handwoong/rainbowletter/letter/controller/LetterControllerTest.java
+++ b/src/test/java/com/handwoong/rainbowletter/letter/controller/LetterControllerTest.java
@@ -13,10 +13,14 @@ import static com.handwoong.rainbowletter.util.RestDocsUtils.getSpecification;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.handwoong.rainbowletter.letter.controller.request.LetterCreateRequest;
+import com.handwoong.rainbowletter.letter.controller.response.LetterBoxResponses;
+import com.handwoong.rainbowletter.letter.controller.response.LetterResponse;
+import com.handwoong.rainbowletter.letter.domain.LetterStatus;
 import com.handwoong.rainbowletter.util.ControllerTestSupporter;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
@@ -56,9 +60,22 @@ class LetterControllerTest extends ControllerTestSupporter {
 
         // when
         final ExtractableResponse<Response> response = findAllLetterBoxByEmail(token);
+        final LetterBoxResponses result = response.body().as(LetterBoxResponses.class);
 
         // then
         assertThat(response.statusCode()).isEqualTo(200);
+
+        assertThat(result.letters().get(0).id()).isEqualTo(2);
+        assertThat(result.letters().get(0).summary()).isEqualTo("콩아 형님이다.");
+        assertThat(result.letters().get(0).status()).isEqualTo(LetterStatus.REQUEST);
+        assertThat(result.letters().get(0).petName()).isEqualTo("콩이");
+        assertThat(result.letters().get(0).createdAt()).isEqualTo(LocalDateTime.of(2023, 1, 2, 12, 0, 0));
+
+        assertThat(result.letters().get(1).id()).isEqualTo(1);
+        assertThat(result.letters().get(1).summary()).isEqualTo("미키야 엄마가 보고싶다.");
+        assertThat(result.letters().get(1).status()).isEqualTo(LetterStatus.REQUEST);
+        assertThat(result.letters().get(1).petName()).isEqualTo("미키");
+        assertThat(result.letters().get(1).createdAt()).isEqualTo(LocalDateTime.of(2023, 1, 1, 12, 0, 0));
     }
 
     private ExtractableResponse<Response> findAllLetterBoxByEmail(final String token) {
@@ -78,9 +95,22 @@ class LetterControllerTest extends ControllerTestSupporter {
 
         // when
         final ExtractableResponse<Response> response = findOne(token);
+        final LetterResponse result = response.body().as(LetterResponse.class);
 
         // then
         assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(result.id()).isEqualTo(1);
+        assertThat(result.summary()).isEqualTo("미키야 엄마가 보고싶다.");
+        assertThat(result.content()).isEqualTo("미키야 엄마가 보고싶다. 엄마는 오늘 미키 생각하면서 그림을 그렸어.");
+        assertThat(result.pet().id()).isEqualTo(2);
+        assertThat(result.pet().name()).isEqualTo("미키");
+        assertThat(result.pet().image().id()).isNull();
+        assertThat(result.pet().image().objectKey()).isNull();
+        assertThat(result.pet().image().url()).isNull();
+        assertThat(result.image().id()).isEqualTo(2);
+        assertThat(result.image().objectKey()).isEqualTo("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        assertThat(result.image().url()).isEqualTo("http://rainbowletter/image");
+        assertThat(result.createdAt()).isEqualTo(LocalDateTime.of(2023, 1, 1, 12, 0, 0));
     }
 
     private ExtractableResponse<Response> findOne(final String token) {

--- a/src/test/java/com/handwoong/rainbowletter/mock/letter/LetterTestContainer.java
+++ b/src/test/java/com/handwoong/rainbowletter/mock/letter/LetterTestContainer.java
@@ -19,8 +19,6 @@ import com.handwoong.rainbowletter.mock.pet.PetTestContainer;
 import com.handwoong.rainbowletter.pet.domain.Pet;
 import com.handwoong.rainbowletter.pet.service.port.PetRepository;
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.List;
 
 public class LetterTestContainer {
     public final Member member = Member.builder()
@@ -52,7 +50,7 @@ public class LetterTestContainer {
             .name("콩이")
             .species("고양이")
             .owner("엄마")
-            .personalities(new HashSet<>(List.of("질투쟁이", "새침함")))
+            .personalities("질투쟁이,새침함")
             .deathAnniversary(null)
             .image(image)
             .favorite(favorite)

--- a/src/test/java/com/handwoong/rainbowletter/mock/pet/FakePetRepository.java
+++ b/src/test/java/com/handwoong/rainbowletter/mock/pet/FakePetRepository.java
@@ -48,12 +48,13 @@ public class FakePetRepository implements PetRepository {
     }
 
     @Override
-    public Optional<Pet> findByEmailAndIdWithImage(final Email email, final Long id) {
+    public Pet findByEmailAndIdWithImageOrElseThrow(final Email email, final Long id) {
         return database.values()
                 .stream()
                 .filter(pet -> pet.member().email().equals(email))
                 .filter(pet -> Objects.nonNull(pet.image()) && pet.image().id().equals(id))
-                .findAny();
+                .findAny()
+                .orElseThrow(() -> new PetResourceNotFoundException(id));
     }
 
     @Override

--- a/src/test/java/com/handwoong/rainbowletter/mock/pet/FakePetRepository.java
+++ b/src/test/java/com/handwoong/rainbowletter/mock/pet/FakePetRepository.java
@@ -1,6 +1,8 @@
 package com.handwoong.rainbowletter.mock.pet;
 
 import com.handwoong.rainbowletter.member.domain.Email;
+import com.handwoong.rainbowletter.pet.controller.response.PetResponse;
+import com.handwoong.rainbowletter.pet.controller.response.PetResponseDto;
 import com.handwoong.rainbowletter.pet.domain.Pet;
 import com.handwoong.rainbowletter.pet.exception.PetResourceNotFoundException;
 import com.handwoong.rainbowletter.pet.service.port.PetRepository;
@@ -26,24 +28,18 @@ public class FakePetRepository implements PetRepository {
 
     @Override
     public Pet findByEmailAndIdOrElseThrow(final Email email, final Long id) {
-        return findByEmailAndId(email, id)
+        return Optional.ofNullable(database.get(id))
+                .filter(pet -> pet.member().email().equals(email))
                 .orElseThrow(() -> new PetResourceNotFoundException(id));
     }
 
     @Override
-    public Optional<Pet> findByEmailAndId(final Email email, final Long id) {
-        final Pet pet = database.get(id);
-        if (Objects.isNull(pet)) {
-            return Optional.empty();
-        }
-        return Optional.ofNullable(pet.member().email().equals(email) ? pet : null);
-    }
-
-    @Override
-    public List<Pet> findAllByEmail(final Email email) {
+    public List<PetResponse> findAllByEmail(final Email email) {
         return database.values()
                 .stream()
                 .filter(pet -> pet.member().email().equals(email))
+                .map(PetResponseDto::from)
+                .map(PetResponse::from)
                 .toList();
     }
 

--- a/src/test/java/com/handwoong/rainbowletter/pet/domain/PetTest.java
+++ b/src/test/java/com/handwoong/rainbowletter/pet/domain/PetTest.java
@@ -60,7 +60,7 @@ class PetTest {
                 .name("두부")
                 .species("고양이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("질투쟁이", "새침함")))
+                .personalities(Personalities.from(new HashSet<>(List.of("질투쟁이", "새침함"))))
                 .deathAnniversary(null)
                 .image(1L)
                 .build();
@@ -73,7 +73,7 @@ class PetTest {
         assertThat(pet.name()).isEqualTo("두부");
         assertThat(pet.species()).isEqualTo("고양이");
         assertThat(pet.owner()).isEqualTo("형님");
-        assertThat(pet.personalities()).containsExactly("질투쟁이", "새침함");
+        assertThat(pet.personalities().split(",")).contains("질투쟁이", "새침함");
         assertThat(pet.deathAnniversary()).isNull();
         assertThat(pet.image()).isEqualTo(image);
         assertThat(pet.member()).isEqualTo(member);
@@ -88,7 +88,7 @@ class PetTest {
                 .name("두부")
                 .species("고양이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("질투쟁이", "새침함")))
+                .personalities("질투쟁이,새침함")
                 .deathAnniversary(null)
                 .image(image)
                 .favorite(favorite)
@@ -98,7 +98,7 @@ class PetTest {
         final PetUpdate request = PetUpdate.builder()
                 .species("호랑이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("잘삐짐")))
+                .personalities(Personalities.from(new HashSet<>(List.of("잘삐짐"))))
                 .deathAnniversary(null)
                 .image(null)
                 .build();
@@ -111,7 +111,7 @@ class PetTest {
         assertThat(updatePet.name()).isEqualTo("두부");
         assertThat(updatePet.species()).isEqualTo("호랑이");
         assertThat(updatePet.owner()).isEqualTo("형님");
-        assertThat(updatePet.personalities()).containsExactly("잘삐짐");
+        assertThat(updatePet.personalities()).isEqualTo("잘삐짐");
         assertThat(updatePet.deathAnniversary()).isNull();
         assertThat(updatePet.image()).isNull();
         assertThat(updatePet.member()).isEqualTo(member);
@@ -126,7 +126,7 @@ class PetTest {
                 .name("두부")
                 .species("고양이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("질투쟁이", "새침함")))
+                .personalities("질투쟁이,새침함")
                 .deathAnniversary(null)
                 .image(image)
                 .favorite(favorite)
@@ -141,7 +141,7 @@ class PetTest {
         assertThat(updatePet.name()).isEqualTo("두부");
         assertThat(updatePet.species()).isEqualTo("고양이");
         assertThat(updatePet.owner()).isEqualTo("형님");
-        assertThat(updatePet.personalities()).containsExactly("질투쟁이", "새침함");
+        assertThat(updatePet.personalities().split(",")).contains("질투쟁이", "새침함");
         assertThat(updatePet.deathAnniversary()).isNull();
         assertThat(updatePet.image()).isNull();
         assertThat(updatePet.member()).isEqualTo(member);
@@ -156,7 +156,7 @@ class PetTest {
                 .name("두부")
                 .species("고양이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("질투쟁이", "새침함")))
+                .personalities("질투쟁이,새침함")
                 .deathAnniversary(null)
                 .image(image)
                 .favorite(favorite)
@@ -171,7 +171,7 @@ class PetTest {
         assertThat(clearedPet.name()).isEqualTo("두부");
         assertThat(clearedPet.species()).isEqualTo("고양이");
         assertThat(clearedPet.owner()).isEqualTo("형님");
-        assertThat(clearedPet.personalities()).containsExactly("질투쟁이", "새침함");
+        assertThat(clearedPet.personalities().split(",")).contains("질투쟁이", "새침함");
         assertThat(clearedPet.deathAnniversary()).isNull();
         assertThat(clearedPet.image()).isNull();
         assertThat(clearedPet.member()).isNull();

--- a/src/test/java/com/handwoong/rainbowletter/pet/infrastructure/PetEntityTest.java
+++ b/src/test/java/com/handwoong/rainbowletter/pet/infrastructure/PetEntityTest.java
@@ -17,8 +17,6 @@ import com.handwoong.rainbowletter.member.domain.PhoneNumber;
 import com.handwoong.rainbowletter.member.infrastructure.MemberEntity;
 import com.handwoong.rainbowletter.pet.domain.Pet;
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -63,7 +61,7 @@ class PetEntityTest {
                 .name("두부")
                 .species("고양이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("질투쟁이", "새침함")))
+                .personalities("질투쟁이,새침함")
                 .deathAnniversary(null)
                 .image(image)
                 .favorite(favorite)
@@ -78,7 +76,7 @@ class PetEntityTest {
         assertThat(petEntity.getName()).isEqualTo("두부");
         assertThat(petEntity.getSpecies()).isEqualTo("고양이");
         assertThat(petEntity.getOwner()).isEqualTo("형님");
-        assertThat(petEntity.getPersonalities()).containsExactly("질투쟁이", "새침함");
+        assertThat(petEntity.getPersonalities()).isEqualTo("질투쟁이,새침함");
         assertThat(petEntity.getDeathAnniversary()).isNull();
         assertThat(petEntity.getImageEntity()).isEqualTo(ImageEntity.from(image));
         assertThat(petEntity.getMemberEntity()).isEqualTo(MemberEntity.from(member));
@@ -93,7 +91,7 @@ class PetEntityTest {
                 .name("두부")
                 .species("고양이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("질투쟁이", "새침함")))
+                .personalities("질투쟁이,새침함")
                 .deathAnniversary(null)
                 .image(image)
                 .favorite(favorite)
@@ -109,7 +107,7 @@ class PetEntityTest {
         assertThat(convertPet.name()).isEqualTo("두부");
         assertThat(convertPet.species()).isEqualTo("고양이");
         assertThat(convertPet.owner()).isEqualTo("형님");
-        assertThat(convertPet.personalities()).containsExactly("질투쟁이", "새침함");
+        assertThat(convertPet.personalities()).isEqualTo("질투쟁이,새침함");
         assertThat(convertPet.deathAnniversary()).isNull();
         assertThat(convertPet.image()).isEqualTo(image);
         assertThat(convertPet.member()).isEqualTo(member);

--- a/src/test/java/com/handwoong/rainbowletter/pet/service/PetServiceTest.java
+++ b/src/test/java/com/handwoong/rainbowletter/pet/service/PetServiceTest.java
@@ -3,7 +3,9 @@ package com.handwoong.rainbowletter.pet.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.handwoong.rainbowletter.favorite.controller.response.FavoriteResponse;
 import com.handwoong.rainbowletter.favorite.domain.Favorite;
+import com.handwoong.rainbowletter.image.controller.response.ImageResponse;
 import com.handwoong.rainbowletter.image.domain.Image;
 import com.handwoong.rainbowletter.image.domain.ImageType;
 import com.handwoong.rainbowletter.member.domain.Email;
@@ -15,6 +17,7 @@ import com.handwoong.rainbowletter.member.domain.Password;
 import com.handwoong.rainbowletter.member.domain.PhoneNumber;
 import com.handwoong.rainbowletter.member.exception.MemberEmailNotFoundException;
 import com.handwoong.rainbowletter.mock.pet.PetTestContainer;
+import com.handwoong.rainbowletter.pet.controller.response.PetResponse;
 import com.handwoong.rainbowletter.pet.domain.Personalities;
 import com.handwoong.rainbowletter.pet.domain.Pet;
 import com.handwoong.rainbowletter.pet.domain.dto.PetCreate;
@@ -88,7 +91,7 @@ class PetServiceTest {
         testContainer.repository.save(pet2);
 
         // when
-        final List<Pet> pets = testContainer.service.findAllByEmail(new Email("handwoong@gmail.com"));
+        final List<PetResponse> pets = testContainer.service.findAllByEmail(new Email("handwoong@gmail.com"));
 
         // then
         assertThat(pets).hasSize(2);
@@ -96,21 +99,19 @@ class PetServiceTest {
         assertThat(pets.get(0).name()).isEqualTo("두부");
         assertThat(pets.get(0).species()).isEqualTo("고양이");
         assertThat(pets.get(0).owner()).isEqualTo("형님");
-        assertThat(pets.get(0).personalities()).isEqualTo("질투쟁이,새침함");
+        assertThat(pets.get(0).personalities()).contains("질투쟁이", "새침함");
         assertThat(pets.get(0).deathAnniversary()).isNull();
-        assertThat(pets.get(0).image()).isEqualTo(image);
-        assertThat(pets.get(0).member()).isEqualTo(member);
-        assertThat(pets.get(0).favorite()).isEqualTo(favorite);
+        assertThat(pets.get(0).image()).isEqualTo(ImageResponse.from(image));
+        assertThat(pets.get(0).favorite()).isEqualTo(FavoriteResponse.from(favorite));
 
         assertThat(pets.get(1).id()).isEqualTo(2);
         assertThat(pets.get(1).name()).isEqualTo("침이");
         assertThat(pets.get(1).species()).isEqualTo("고양이");
         assertThat(pets.get(1).owner()).isEqualTo("형님");
-        assertThat(pets.get(1).personalities()).isEqualTo("애교쟁이");
+        assertThat(pets.get(1).personalities()).contains("애교쟁이");
         assertThat(pets.get(1).deathAnniversary()).isNull();
-        assertThat(pets.get(1).image()).isEqualTo(image);
-        assertThat(pets.get(1).member()).isEqualTo(member);
-        assertThat(pets.get(1).favorite()).isEqualTo(favorite);
+        assertThat(pets.get(1).image()).isEqualTo(ImageResponse.from(image));
+        assertThat(pets.get(1).favorite()).isEqualTo(FavoriteResponse.from(favorite));
     }
 
     @Test
@@ -376,7 +377,8 @@ class PetServiceTest {
         testContainer.service.delete(email, 1L);
 
         // then
-        assertThat(testContainer.repository.findByEmailAndId(email, 1L)).isEmpty();
+        assertThatThrownBy(() -> testContainer.repository.findByIdOrElseThrow(1L))
+                .isInstanceOf(PetResourceNotFoundException.class);
     }
 
     @Test

--- a/src/test/java/com/handwoong/rainbowletter/pet/service/PetServiceTest.java
+++ b/src/test/java/com/handwoong/rainbowletter/pet/service/PetServiceTest.java
@@ -15,6 +15,7 @@ import com.handwoong.rainbowletter.member.domain.Password;
 import com.handwoong.rainbowletter.member.domain.PhoneNumber;
 import com.handwoong.rainbowletter.member.exception.MemberEmailNotFoundException;
 import com.handwoong.rainbowletter.mock.pet.PetTestContainer;
+import com.handwoong.rainbowletter.pet.domain.Personalities;
 import com.handwoong.rainbowletter.pet.domain.Pet;
 import com.handwoong.rainbowletter.pet.domain.dto.PetCreate;
 import com.handwoong.rainbowletter.pet.domain.dto.PetUpdate;
@@ -65,7 +66,7 @@ class PetServiceTest {
                 .name("두부")
                 .species("고양이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("질투쟁이", "새침함")))
+                .personalities("질투쟁이,새침함")
                 .deathAnniversary(null)
                 .image(image)
                 .favorite(favorite)
@@ -75,7 +76,7 @@ class PetServiceTest {
                 .name("침이")
                 .species("고양이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("애교쟁이")))
+                .personalities("애교쟁이")
                 .deathAnniversary(null)
                 .image(image)
                 .favorite(favorite)
@@ -95,7 +96,7 @@ class PetServiceTest {
         assertThat(pets.get(0).name()).isEqualTo("두부");
         assertThat(pets.get(0).species()).isEqualTo("고양이");
         assertThat(pets.get(0).owner()).isEqualTo("형님");
-        assertThat(pets.get(0).personalities()).containsExactly("질투쟁이", "새침함");
+        assertThat(pets.get(0).personalities()).isEqualTo("질투쟁이,새침함");
         assertThat(pets.get(0).deathAnniversary()).isNull();
         assertThat(pets.get(0).image()).isEqualTo(image);
         assertThat(pets.get(0).member()).isEqualTo(member);
@@ -105,7 +106,7 @@ class PetServiceTest {
         assertThat(pets.get(1).name()).isEqualTo("침이");
         assertThat(pets.get(1).species()).isEqualTo("고양이");
         assertThat(pets.get(1).owner()).isEqualTo("형님");
-        assertThat(pets.get(1).personalities()).containsExactly("애교쟁이");
+        assertThat(pets.get(1).personalities()).isEqualTo("애교쟁이");
         assertThat(pets.get(1).deathAnniversary()).isNull();
         assertThat(pets.get(1).image()).isEqualTo(image);
         assertThat(pets.get(1).member()).isEqualTo(member);
@@ -120,7 +121,7 @@ class PetServiceTest {
                 .name("두부")
                 .species("고양이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("질투쟁이", "새침함")))
+                .personalities(Personalities.from(new HashSet<>(List.of("질투쟁이", "새침함"))))
                 .deathAnniversary(null)
                 .image(null)
                 .build();
@@ -136,7 +137,7 @@ class PetServiceTest {
         assertThat(pet.name()).isEqualTo("두부");
         assertThat(pet.species()).isEqualTo("고양이");
         assertThat(pet.owner()).isEqualTo("형님");
-        assertThat(pet.personalities()).containsExactly("질투쟁이", "새침함");
+        assertThat(pet.personalities().split(",")).contains("질투쟁이", "새침함");
         assertThat(pet.deathAnniversary()).isNull();
         assertThat(pet.image()).isNull();
         assertThat(pet.member()).isEqualTo(member);
@@ -151,7 +152,7 @@ class PetServiceTest {
                 .name("두부")
                 .species("고양이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("질투쟁이", "새침함")))
+                .personalities(Personalities.from(new HashSet<>(List.of("질투쟁이", "새침함"))))
                 .deathAnniversary(null)
                 .image(1L)
                 .build();
@@ -168,7 +169,7 @@ class PetServiceTest {
         assertThat(pet.name()).isEqualTo("두부");
         assertThat(pet.species()).isEqualTo("고양이");
         assertThat(pet.owner()).isEqualTo("형님");
-        assertThat(pet.personalities()).containsExactly("질투쟁이", "새침함");
+        assertThat(pet.personalities().split(",")).contains("질투쟁이", "새침함");
         assertThat(pet.deathAnniversary()).isNull();
         assertThat(pet.image()).isEqualTo(image);
         assertThat(pet.member()).isEqualTo(member);
@@ -183,7 +184,7 @@ class PetServiceTest {
                 .name("두부")
                 .species("고양이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("질투쟁이", "새침함")))
+                .personalities(Personalities.from(new HashSet<>(List.of("질투쟁이", "새침함"))))
                 .deathAnniversary(null)
                 .image(1L)
                 .build();
@@ -206,7 +207,7 @@ class PetServiceTest {
                 .name("두부")
                 .species("고양이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("질투쟁이", "새침함")))
+                .personalities("질투쟁이,새침함")
                 .deathAnniversary(null)
                 .image(image)
                 .favorite(favorite)
@@ -216,7 +217,7 @@ class PetServiceTest {
         final PetUpdate request = PetUpdate.builder()
                 .species("호랑이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("잘삐짐")))
+                .personalities(Personalities.from(new HashSet<>(List.of("잘삐짐"))))
                 .deathAnniversary(null)
                 .image(null)
                 .build();
@@ -232,7 +233,7 @@ class PetServiceTest {
         assertThat(updatedPet.name()).isEqualTo("두부");
         assertThat(updatedPet.species()).isEqualTo("호랑이");
         assertThat(updatedPet.owner()).isEqualTo("형님");
-        assertThat(updatedPet.personalities()).containsExactly("잘삐짐");
+        assertThat(updatedPet.personalities()).isEqualTo("잘삐짐");
         assertThat(updatedPet.deathAnniversary()).isNull();
         assertThat(updatedPet.image()).isNull();
         assertThat(updatedPet.member()).isEqualTo(member);
@@ -248,7 +249,7 @@ class PetServiceTest {
                 .name("두부")
                 .species("고양이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("질투쟁이", "새침함")))
+                .personalities("질투쟁이,새침함")
                 .deathAnniversary(null)
                 .image(null)
                 .favorite(favorite)
@@ -258,7 +259,7 @@ class PetServiceTest {
         final PetUpdate request = PetUpdate.builder()
                 .species("호랑이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("잘삐짐")))
+                .personalities(Personalities.from(new HashSet<>(List.of("잘삐짐"))))
                 .deathAnniversary(null)
                 .image(1L)
                 .build();
@@ -275,7 +276,7 @@ class PetServiceTest {
         assertThat(updatedPet.name()).isEqualTo("두부");
         assertThat(updatedPet.species()).isEqualTo("호랑이");
         assertThat(updatedPet.owner()).isEqualTo("형님");
-        assertThat(updatedPet.personalities()).containsExactly("잘삐짐");
+        assertThat(updatedPet.personalities()).isEqualTo("잘삐짐");
         assertThat(updatedPet.deathAnniversary()).isNull();
         assertThat(updatedPet.image()).isEqualTo(image);
         assertThat(updatedPet.member()).isEqualTo(member);
@@ -290,7 +291,7 @@ class PetServiceTest {
         final PetUpdate request = PetUpdate.builder()
                 .species("호랑이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("잘삐짐")))
+                .personalities(Personalities.from(new HashSet<>(List.of("잘삐짐"))))
                 .deathAnniversary(null)
                 .image(null)
                 .build();
@@ -313,7 +314,7 @@ class PetServiceTest {
                 .name("두부")
                 .species("고양이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("질투쟁이", "새침함")))
+                .personalities("질투쟁이,새침함")
                 .deathAnniversary(null)
                 .image(image)
                 .favorite(favorite)
@@ -331,7 +332,7 @@ class PetServiceTest {
         assertThat(deletedImagePet.name()).isEqualTo("두부");
         assertThat(deletedImagePet.species()).isEqualTo("고양이");
         assertThat(deletedImagePet.owner()).isEqualTo("형님");
-        assertThat(deletedImagePet.personalities()).containsExactly("질투쟁이", "새침함");
+        assertThat(deletedImagePet.personalities().split(",")).contains("질투쟁이", "새침함");
         assertThat(deletedImagePet.deathAnniversary()).isNull();
         assertThat(deletedImagePet.image()).isNull();
         assertThat(deletedImagePet.member()).isEqualTo(member);
@@ -361,7 +362,7 @@ class PetServiceTest {
                 .name("두부")
                 .species("고양이")
                 .owner("형님")
-                .personalities(new HashSet<>(List.of("질투쟁이", "새침함")))
+                .personalities("질투쟁이,새침함")
                 .deathAnniversary(null)
                 .image(image)
                 .favorite(favorite)

--- a/src/test/resources/sql/pet.sql
+++ b/src/test/resources/sql/pet.sql
@@ -9,16 +9,10 @@ VALUES ('2023-01-01 12:00:00.000000', '2023-01-01 12:00:00.000000', 0, 0, true, 
 INSERT INTO favorite (created_at, updated_at, total, day_increase_count, can_increase, last_increase_at)
 VALUES ('2023-01-01 12:00:00.000000', '2023-01-01 12:00:00.000000', 0, 0, true, '2023-01-01 12:00:00.000000');
 
-INSERT INTO pet (created_at, updated_at, favorite_id, image_id, member_id, name, species, owner, death_anniversary)
-VALUES ('2023-01-01 12:00:00.000000', '2023-01-01 12:00:00.000000', 1, 1, 2, '콩이', '고양이', '형님', '2023-01-01');
+INSERT INTO pet (created_at, updated_at, favorite_id, image_id, member_id, name, species, owner, death_anniversary, personalities)
+VALUES ('2023-01-01 12:00:00.000000', '2023-01-01 12:00:00.000000', 1, 1, 2, '콩이', '고양이', '형님', '2023-01-01', '활발한,잘삐짐');
 
-INSERT INTO pet (created_at, updated_at, favorite_id, image_id, member_id, name, species, owner, death_anniversary)
-VALUES ('2023-01-01 12:00:00.000000', '2023-01-01 12:00:00.000000', 2, null, 2, '미키', '강아지', '엄마', null);
-
-INSERT INTO pet_personality (pet_id, personality)
-VALUES (1, '활발한');
-
-INSERT INTO pet_personality (pet_id, personality)
-VALUES (1, '잘삐짐');
+INSERT INTO pet (created_at, updated_at, favorite_id, image_id, member_id, name, species, owner, death_anniversary, personalities)
+VALUES ('2023-01-01 12:00:00.000000', '2023-01-01 12:00:00.000000', 2, null, 2, '미키', '강아지', '엄마', null, '');
 
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
## 설명

도메인 객체와 영속 객체를 분리함으로써 더티 체킹과 같은 기능을 사용할 수 없다.
JPA를 통해 조회 후 영속 객체 -> 도메인 객체로의 변환에서 지연 로딩으로 설정한 값들에 대해서 무조건 추가 쿼리가 발생한다.
읽기용은 DTO로 조회, 쓰기용은 연관 엔티티까지 한번에 조회하도록 개선한다.

Close #71 