### PR TITLE
feat(favorite): 좋아요 가능 횟수 00시 초기화

### DIFF
--- a/src/main/java/com/handwoong/rainbowletter/favorite/controller/port/FavoriteService.java
+++ b/src/main/java/com/handwoong/rainbowletter/favorite/controller/port/FavoriteService.java
@@ -4,4 +4,6 @@ import com.handwoong.rainbowletter.favorite.domain.Favorite;
 
 public interface FavoriteService {
     Favorite increase(Long id);
+
+    void resetDayIncreaseCount();
 }

--- a/src/main/java/com/handwoong/rainbowletter/favorite/domain/Favorite.java
+++ b/src/main/java/com/handwoong/rainbowletter/favorite/domain/Favorite.java
@@ -1,7 +1,6 @@
 package com.handwoong.rainbowletter.favorite.domain;
 
 import com.handwoong.rainbowletter.favorite.exception.FavoriteIncreaseNotValidException;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
 
@@ -14,13 +13,6 @@ public record Favorite(Long id, int total, int dayIncreaseCount, boolean canIncr
                 .canIncrease(true)
                 .lastIncreaseAt(LocalDateTime.now())
                 .build();
-    }
-
-    public Favorite resetDayIncreaseCount() {
-        if (lastIncreaseAt.isBefore(LocalDate.now().atStartOfDay())) {
-            return resetCount(total, 0);
-        }
-        return this;
     }
 
     public Favorite increase() {

--- a/src/main/java/com/handwoong/rainbowletter/favorite/infrastructure/FavoriteRepositoryImpl.java
+++ b/src/main/java/com/handwoong/rainbowletter/favorite/infrastructure/FavoriteRepositoryImpl.java
@@ -1,7 +1,10 @@
 package com.handwoong.rainbowletter.favorite.infrastructure;
 
+import static com.handwoong.rainbowletter.favorite.infrastructure.QFavoriteEntity.favoriteEntity;
+
 import com.handwoong.rainbowletter.favorite.domain.Favorite;
 import com.handwoong.rainbowletter.favorite.service.port.FavoriteRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -9,6 +12,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 @RequiredArgsConstructor
 public class FavoriteRepositoryImpl implements FavoriteRepository {
+    private final JPAQueryFactory queryFactory;
     private final FavoriteJpaRepository favoriteJpaRepository;
 
     @Override
@@ -19,5 +23,19 @@ public class FavoriteRepositoryImpl implements FavoriteRepository {
     @Override
     public Optional<Favorite> findById(final Long id) {
         return favoriteJpaRepository.findById(id).map(FavoriteEntity::toModel);
+    }
+
+    @Override
+    public void resetIncreaseCount() {
+        queryFactory.update(favoriteEntity)
+                .set(favoriteEntity.dayIncreaseCount, 0)
+                .execute();
+    }
+
+    @Override
+    public void resetCanIncrease() {
+        queryFactory.update(favoriteEntity)
+                .set(favoriteEntity.canIncrease, true)
+                .execute();
     }
 }

--- a/src/main/java/com/handwoong/rainbowletter/favorite/service/FavoriteServiceImpl.java
+++ b/src/main/java/com/handwoong/rainbowletter/favorite/service/FavoriteServiceImpl.java
@@ -5,6 +5,8 @@ import com.handwoong.rainbowletter.favorite.domain.Favorite;
 import com.handwoong.rainbowletter.favorite.exception.FavoriteResourceNotFoundException;
 import com.handwoong.rainbowletter.favorite.service.port.FavoriteRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,10 +21,17 @@ public class FavoriteServiceImpl implements FavoriteService {
     public Favorite increase(final Long id) {
         final Favorite favorite = favoriteRepository.findById(id)
                 .orElseThrow(() -> new FavoriteResourceNotFoundException(id));
-
-        final Favorite resetFavorite = favorite.resetDayIncreaseCount();
-        final Favorite incrementedFavorite = resetFavorite.increase();
+        final Favorite incrementedFavorite = favorite.increase();
         favoriteRepository.save(incrementedFavorite);
         return incrementedFavorite;
+    }
+
+    @Override
+    @Async
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void resetDayIncreaseCount() {
+        favoriteRepository.resetIncreaseCount();
+        favoriteRepository.resetCanIncrease();
     }
 }

--- a/src/main/java/com/handwoong/rainbowletter/favorite/service/port/FavoriteRepository.java
+++ b/src/main/java/com/handwoong/rainbowletter/favorite/service/port/FavoriteRepository.java
@@ -7,4 +7,8 @@ public interface FavoriteRepository {
     Favorite save(Favorite favorite);
 
     Optional<Favorite> findById(Long id);
+
+    void resetIncreaseCount();
+
+    void resetCanIncrease();
 }

--- a/src/test/java/com/handwoong/rainbowletter/favorite/domain/FavoriteTest.java
+++ b/src/test/java/com/handwoong/rainbowletter/favorite/domain/FavoriteTest.java
@@ -23,51 +23,6 @@ class FavoriteTest {
     }
 
     @Test
-    void 일일_좋아요_카운트를_초기화한다() {
-        // given
-        final Favorite favorite = Favorite.builder()
-                .id(1L)
-                .total(10)
-                .dayIncreaseCount(3)
-                .canIncrease(false)
-                .lastIncreaseAt(LocalDateTime.of(1900, 1, 1, 0, 0))
-                .build();
-
-        // when
-        final Favorite initFavorite = favorite.resetDayIncreaseCount();
-
-        // then
-        assertThat(initFavorite.id()).isEqualTo(1);
-        assertThat(initFavorite.total()).isEqualTo(10);
-        assertThat(initFavorite.dayIncreaseCount()).isZero();
-        assertThat(initFavorite.canIncrease()).isTrue();
-        assertThat(initFavorite.lastIncreaseAt().toLocalDate()).isEqualTo(LocalDateTime.now().toLocalDate());
-    }
-
-    @Test
-    void 오늘_날짜와_업데이트_날짜가_같다면_일일_좋아요_카운트를_초기화하지_않는다() {
-        // given
-        final LocalDateTime today = LocalDateTime.now();
-        final Favorite favorite = Favorite.builder()
-                .id(1L)
-                .total(10)
-                .dayIncreaseCount(3)
-                .canIncrease(false)
-                .lastIncreaseAt(today)
-                .build();
-
-        // when
-        final Favorite initFavorite = favorite.resetDayIncreaseCount();
-
-        // then
-        assertThat(initFavorite.id()).isEqualTo(1);
-        assertThat(initFavorite.total()).isEqualTo(10);
-        assertThat(initFavorite.dayIncreaseCount()).isEqualTo(3);
-        assertThat(initFavorite.canIncrease()).isFalse();
-        assertThat(initFavorite.lastIncreaseAt()).isEqualTo(today);
-    }
-
-    @Test
     void 좋아요를_증가시킨다() {
         // given
         final Favorite favorite = Favorite.builder()

--- a/src/test/java/com/handwoong/rainbowletter/favorite/service/FavoriteServiceTest.java
+++ b/src/test/java/com/handwoong/rainbowletter/favorite/service/FavoriteServiceTest.java
@@ -7,7 +7,6 @@ import com.handwoong.rainbowletter.favorite.domain.Favorite;
 import com.handwoong.rainbowletter.favorite.exception.FavoriteIncreaseNotValidException;
 import com.handwoong.rainbowletter.mock.favorite.FakeFavoriteRepository;
 import com.handwoong.rainbowletter.mock.favorite.FavoriteTestContainer;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
@@ -24,32 +23,6 @@ class FavoriteServiceTest {
         // then
         assertThat(increasedFavorite.id()).isEqualTo(1);
         assertThat(increasedFavorite.total()).isEqualTo(1);
-        assertThat(increasedFavorite.dayIncreaseCount()).isEqualTo(1);
-        assertThat(increasedFavorite.canIncrease()).isTrue();
-        assertThat(increasedFavorite.lastIncreaseAt().toLocalDate()).isEqualTo(LocalDateTime.now().toLocalDate());
-    }
-
-    @Test
-    void 좋아요_증가전_업데이트_날짜가_과거라면_일일_좋아요_가능_횟수를_초기화한다() {
-        // given
-        final Favorite favorite = Favorite.builder()
-                .total(10)
-                .dayIncreaseCount(3)
-                .canIncrease(false)
-                .build();
-
-        final FakeFavoriteRepository favoriteRepository =
-                new FakeFavoriteRepository(LocalDate.of(1900, 1, 1).atStartOfDay());
-        favoriteRepository.save(favorite);
-
-        final FavoriteServiceImpl favoriteService = new FavoriteServiceImpl(favoriteRepository);
-
-        // when
-        final Favorite increasedFavorite = favoriteService.increase(1L);
-
-        // then
-        assertThat(increasedFavorite.id()).isEqualTo(1);
-        assertThat(increasedFavorite.total()).isEqualTo(11);
         assertThat(increasedFavorite.dayIncreaseCount()).isEqualTo(1);
         assertThat(increasedFavorite.canIncrease()).isTrue();
         assertThat(increasedFavorite.lastIncreaseAt().toLocalDate()).isEqualTo(LocalDateTime.now().toLocalDate());

--- a/src/test/java/com/handwoong/rainbowletter/mock/favorite/FakeFavoriteRepository.java
+++ b/src/test/java/com/handwoong/rainbowletter/mock/favorite/FakeFavoriteRepository.java
@@ -48,4 +48,12 @@ public class FakeFavoriteRepository implements FavoriteRepository {
                 .filter(favorite -> favorite.id().equals(id))
                 .findAny();
     }
+
+    @Override
+    public void resetIncreaseCount() {
+    }
+
+    @Override
+    public void resetCanIncrease() {
+    }
 }


### PR DESCRIPTION
## 설명

현재 하루 최대 수치의 좋아요를 눌렀다면 다음날 좋아요 재요청시 초기화되는 로직입니다.
프론트측에서 하루 최대 좋아요를 눌렀다면 좋아요 버튼을 막기엔 번거롭다는 요청으로 매일 00시에 좋아요 수치를 초기화 시키는 기능이 필요합니다.