### PR TITLE
V1.0.1 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.handwoong'
-version = '1.0.0'
+version = '1.0.1'
 
 java {
     sourceCompatibility = '17'

--- a/src/main/java/com/handwoong/rainbowletter/letter/domain/Content.java
+++ b/src/main/java/com/handwoong/rainbowletter/letter/domain/Content.java
@@ -4,7 +4,7 @@ import com.handwoong.rainbowletter.letter.exception.ContentFormatNotValidExcepti
 import org.springframework.util.StringUtils;
 
 public record Content(String content) {
-    public static final int MAX_CONTENT_LENGTH = 1000;
+    public static final int MAX_CONTENT_LENGTH = 2000;
 
     public Content {
         validateNull(content);


### PR DESCRIPTION
## 설명

이전된 데이터의 편지 본문의 길이가 1000자보다 길어 도메인 객체 유효성 검사를 통과하지 못하는 현상을 수정함.